### PR TITLE
fix: add missing step3 field to CrashState and correct return value

### DIFF
--- a/10_persistence.ipynb
+++ b/10_persistence.ipynb
@@ -440,7 +440,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "095de12d",
    "metadata": {},
    "outputs": [],
@@ -449,12 +449,13 @@
     "class CrashState(TypedDict):\n",
     "    input: str\n",
     "    step1: str\n",
-    "    step2: str"
+    "    step2: str\n",
+    "    step3: str"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "13365a36",
    "metadata": {},
    "outputs": [],
@@ -471,7 +472,7 @@
     "\n",
     "def step_3(state: CrashState) -> CrashState:\n",
     "    print(\"✅ Step 3 executed\")\n",
-    "    return {\"done\": True}"
+    "    return {\"step3\": \"done\"}"
    ]
   },
   {


### PR DESCRIPTION
## Description
Fixed two bugs in the fault tolerance example in `10_persistence.ipynb`:

1. **Missing state field**: Added `step3: str` to `CrashState` TypedDict
2. **Incorrect return value**: Fixed `step_3()` function to return `{"step3": "done"}` instead of `{"done": True}`

## Problem
The original code had inconsistent state management:
- `CrashState` defined `step1` and `step2` but was missing `step3`
- `step_3()` returned `{"done": True}` which doesn't match the state schema
- This would cause state tracking issues in the workflow

## Solution
- Added `step3: str` field to maintain consistency with `step1` and `step2`
- Changed return value to `{"step3": "done"}` to match the expected state structure
- Now all three steps follow the same pattern